### PR TITLE
Set variables for keystone ports

### DIFF
--- a/roles/os-common/defaults/main.yml
+++ b/roles/os-common/defaults/main.yml
@@ -30,6 +30,10 @@ rabbitmq_username: openstack
 # Password for 'admin' user
 # keystone_admin_password: <password>
 
+# Default ports
+keystone_admin_port: 35357
+keystone_public_port: 5000
+
 # Password for 'nova' user
 # nova_user_password: <password>
 

--- a/roles/os-glance/tasks/glance_project_access.yml
+++ b/roles/os-glance/tasks/glance_project_access.yml
@@ -25,7 +25,7 @@
       password: "{{ glance_user_password  }}"
       domain_name: "Default"
       email: "{{item.name}}@example.com"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - { name: "glance", project: "admin" }
 
@@ -39,6 +39,6 @@
       user_name: "{{item.user}}"
       project_name: "{{item.project}}"
       role_name: "{{item.role}}"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - { user: "glance", project: "service", role: "admin"}

--- a/roles/os-glance/tasks/glance_service_entities.yml
+++ b/roles/os-glance/tasks/glance_service_entities.yml
@@ -23,7 +23,7 @@
       service_name: "glance"
       service_type: "image"
       description: "Glance Image Service"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
 
   - name: Create glance endpoints
     delegate_to: "{{ groups['openstack_identity'][0] }}"
@@ -42,4 +42,4 @@
           interface: "internal"
         - url: "http://{{ groups['openstack_image'][0] }}:9292"
           interface: "admin"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"

--- a/roles/os-glance/templates/glance-api.conf.j2
+++ b/roles/os-glance/templates/glance-api.conf.j2
@@ -9,8 +9,8 @@ debug = True
 connection = mysql+pymysql://glance:{{ glance_database_password }}@{{ groups['dbservers'][0] }}/glance
 
 [keystone_authtoken]
-auth_uri = http://{{ groups['openstack_identity'][0] }}:5000
-auth_url = http://{{ groups['openstack_identity'][0] }}:35357
+auth_uri = http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}
+auth_url = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}
 auth_type = password
 project_domain_id = default
 user_domain_id = default

--- a/roles/os-glance/templates/glance-registry.conf.j2
+++ b/roles/os-glance/templates/glance-registry.conf.j2
@@ -8,8 +8,8 @@ debug = True
 connection = mysql+pymysql://glance:{{ glance_database_password }}@{{ groups['dbservers'][0] }}/glance
 
 [keystone_authtoken]
-auth_uri = http://{{ groups['openstack_identity'][0] }}:5000
-auth_url = http://{{ groups['openstack_identity'][0] }}:35357
+auth_uri = http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}
+auth_url = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}
 auth_type = password
 project_domain_id = default
 user_domain_id = default

--- a/roles/os-heat/tasks/heat_project_access.yml
+++ b/roles/os-heat/tasks/heat_project_access.yml
@@ -19,7 +19,7 @@
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       command: "ensure_domain"
       domain_name: "{{ heat_domain }}"
 
@@ -35,7 +35,7 @@
       password: "{{ item.password }}"
       domain_name: "{{ item.domain }}"
       email: "{{item.name}}@example.com"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - name: "heat"
         project: "admin"
@@ -51,7 +51,7 @@
     keystone:
       command: "ensure_role"
       role_name: "{{item}}"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"
@@ -69,6 +69,6 @@
       user_name: "{{ item.user }}"
       project_name: "{{ item.project }}"
       role_name: "{{ item.role }}"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - { user: "heat", project: "service", role: "admin"}

--- a/roles/os-heat/tasks/heat_service_entities.yml
+++ b/roles/os-heat/tasks/heat_service_entities.yml
@@ -23,7 +23,7 @@
       service_name: "{{ item.name }}"
       service_type: "{{ item.type }}"
       description: "{{ item.description }}"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - { name: "heat", type: "orchestration", description: "OpenStack Orchestration" }
       - { name: "heat-cfn", type: "cloudformation", description: "OpenStack Orchestration"}
@@ -45,7 +45,7 @@
           interface: "internal"
         - url: "{{ item.admin_url }}"
           interface: "admin"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - name: heat
         type: orchestration

--- a/roles/os-heat/templates/heat.conf.j2
+++ b/roles/os-heat/templates/heat.conf.j2
@@ -3,14 +3,14 @@
 debug = True
 {% endif %}
 rpc_backend = rabbit
-heat_metadata_server_url = "http://{{ groups['openstack_orchestration'][0] }}:8000"
-heat_waitcondition_server_url = "http://{{ groups['openstack_orchestration'][0] }}:8000/v1/waitcondition"
-stack_domain_admin = "{{ heat_domain_admin }}"
-stack_domain_admin_password = "{{ heat_domain_admin_password }}"
-stack_user_domain_name = "{{ heat_domain }}"
+heat_metadata_server_url = http://{{ groups['openstack_orchestration'][0] }}:8000
+heat_waitcondition_server_url = http://{{ groups['openstack_orchestration'][0] }}:8000/v1/waitcondition
+stack_domain_admin = {{ heat_domain_admin }}
+stack_domain_admin_password = {{ heat_domain_admin_password }}
+stack_user_domain_name = {{ heat_domain }}
 
 [database]
-connection = "mysql+pymysql://heat:{{ heat_database_password }}@{{ groups['dbservers'][0] }}/heat"
+connection = mysql+pymysql://heat:{{ heat_database_password }}@{{ groups['dbservers'][0] }}/heat
 
 [oslo_messaging_rabbit]
 rabbit_host = {{ groups['messaging_servers'][0] }}
@@ -18,8 +18,8 @@ rabbit_userid = {{ rabbitmq_username }}
 rabbit_password = {{ rabbitmq_password }}
 
 [keystone_authtoken]
-auth_uri = http://{{ groups['openstack_identity'][0] }}:5000
-auth_url = http://{{ groups['openstack_identity'][0] }}:35357
+auth_uri = http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}
+auth_url = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}
 auth_type = password
 project_domain_id = default
 user_domain_id = default
@@ -28,18 +28,14 @@ username = heat
 password = {{ heat_user_password }}
 
 [trustee]
-auth_uri = http://{{ groups['openstack_identity'][0] }}:5000
-auth_url = http://{{ groups['openstack_identity'][0] }}:35357
+auth_url = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}
 auth_type = password
-project_domain_id = default
-user_domain_id = default
-project_name = service
 username = heat
+user_domain_id = default
 password = {{ heat_user_password }}
-rpc_backend = rabbit
 
 [clients_keystone]
-auth_uri = http://{{ groups['openstack_identity'][0] }}:5000
+auth_uri = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}
 
 [ec2authtoken]
-auth_uri = http://{{ groups['openstack_identity'][0] }}:5000
+auth_uri = http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}

--- a/roles/os-keystone/tasks/keystone_bootstrap.yml
+++ b/roles/os-keystone/tasks/keystone_bootstrap.yml
@@ -21,8 +21,8 @@
       --bootstrap-project-name admin
       --bootstrap-role-name admin
       --bootstrap-service-name keystone
-      --bootstrap-admin-url "http://{{ groups['openstack_identity'][0] }}:35357/v3"
-      --bootstrap-public-url "http://{{ groups['openstack_identity'][0] }}:5000/v3"
-      --bootstrap-internal-url "http://{{ groups['openstack_identity'][0] }}:5000/v3"
+      --bootstrap-admin-url "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
+      --bootstrap-public-url "http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}/v3"
+      --bootstrap-internal-url "http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}/v3"
     become: yes
     become_user: keystone

--- a/roles/os-keystone/tasks/keystone_demo_access.yml
+++ b/roles/os-keystone/tasks/keystone_demo_access.yml
@@ -19,7 +19,7 @@
       project_name: "demo"
       domain_name: Default
       description: "Demo Project"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"
@@ -32,7 +32,7 @@
       password: "{{ keystone_demo_password  }}"
       domain_name: "Default"
       email: "demo@example.com"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"
@@ -41,7 +41,7 @@
     keystone:
       command: "ensure_role"
       role_name: "demo"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"
@@ -52,7 +52,7 @@
       user_name: "demo"
       project_name: "demo"
       role_name: "demo"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"

--- a/roles/os-keystone/tasks/keystone_project_access.yml
+++ b/roles/os-keystone/tasks/keystone_project_access.yml
@@ -19,7 +19,7 @@
       project_name: "{{ item.name }}"
       domain_name: Default
       description: "{{ item.desc }}"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"
@@ -30,7 +30,7 @@
     keystone:
       command: "ensure_role"
       role_name: "{{item}}"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"

--- a/roles/os-keystone/tasks/keystone_service_entities.yml
+++ b/roles/os-keystone/tasks/keystone_service_entities.yml
@@ -19,7 +19,7 @@
       service_name: "keystone"
       service_type: "identity"
       description: "OpenStack Identity"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"
@@ -31,13 +31,13 @@
       service_name: "keystone"
       service_type: "identity"
       endpoint_list:
-        - url: "http://{{ groups['openstack_identity'][0] }}:5000/v3"
+        - url: "http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}/v3"
           interface: "public"
-        - url: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+        - url: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
           interface: "admin"
-        - url: "http://{{ groups['openstack_identity'][0] }}:5000/v3"
+        - url: "http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}/v3"
           interface: "internal"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
       login_user: admin
       login_password: "{{ keystone_admin_password }}"
       login_project_name: "admin"

--- a/roles/os-keystone/templates/openrc.j2
+++ b/roles/os-keystone/templates/openrc.j2
@@ -6,6 +6,6 @@ export OS_PROJECT_NAME=admin
 export OS_TENANT_NAME=admin
 export OS_USERNAME=admin
 export OS_PASSWORD={{ keystone_admin_password }}
-export OS_AUTH_URL="http://{{ groups['openstack_identity'][0] }}:35357/v3"
+export OS_AUTH_URL="http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
 export OS_IDENTITY_API_VERSION=3
 export OS_IMAGE_API_VERSION=2

--- a/roles/os-neutron/tasks/neutron_project_access.yml
+++ b/roles/os-neutron/tasks/neutron_project_access.yml
@@ -25,7 +25,7 @@
       password: "{{ neutron_user_password  }}"
       domain_name: "Default"
       email: "{{item.name}}@example.com"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - { name: "neutron", project: "admin" }
 
@@ -39,6 +39,6 @@
       user_name: "{{item.user}}"
       project_name: "{{item.project}}"
       role_name: "{{item.role}}"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - { user: "neutron", project: "service", role: "admin"}

--- a/roles/os-neutron/tasks/neutron_service_entities.yml
+++ b/roles/os-neutron/tasks/neutron_service_entities.yml
@@ -23,7 +23,7 @@
       service_name: "neutron"
       service_type: "network"
       description: "OpenStack Networking"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
 
   - name: Create neutron endpoints
     delegate_to: "{{ groups['openstack_identity'][0] }}"
@@ -42,4 +42,4 @@
           interface: "internal"
         - url: "http://{{ groups['openstack_networking'][0] }}:9696"
           interface: "admin"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"

--- a/roles/os-neutron/templates/metadata_agent.ini.j2
+++ b/roles/os-neutron/templates/metadata_agent.ini.j2
@@ -1,6 +1,6 @@
 [DEFAULT]
-auth_uri = "http://{{ groups['openstack_identity'][0] }}:5000"
-auth_url = "http://{{ groups['openstack_identity'][0] }}:35357"
+auth_uri = "http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}"
+auth_url = "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}"
 auth_region = RegionOne
 auth_plugin = password
 project_domain_id = default

--- a/roles/os-neutron/templates/neutron.conf.j2
+++ b/roles/os-neutron/templates/neutron.conf.j2
@@ -15,17 +15,17 @@ nova_url = http://{{ groups['openstack_compute_controller'][0] }}:8774/v2
 connection = mysql+pymysql://neutron:{{ neutron_database_password }}@{{ groups['dbservers'][0] }}/neutron
 
 [keystone_authtoken]
-auth_uri = http://{{ groups['openstack_identity'][0] }}:5000
+auth_uri = http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}
 project_domain_id = default
 project_name = service
 user_domain_id = default
 password = {{ neutron_user_password }}
 username = neutron
-auth_url = http://{{ groups['openstack_identity'][0] }}:35357
+auth_url = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}
 auth_type = password
 
 [nova]
-auth_url = http://{{ groups['openstack_identity'][0] }}:35357
+auth_url = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}
 auth_type = password
 project_domain_id = default
 user_domain_id = default

--- a/roles/os-nova/tasks/nova_project_access.yml
+++ b/roles/os-nova/tasks/nova_project_access.yml
@@ -25,7 +25,7 @@
       password: "{{ nova_user_password  }}"
       domain_name: "Default"
       email: "{{item.name}}@example.com"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - { name: "nova", project: "admin" }
 
@@ -39,6 +39,6 @@
       user_name: "{{item.user}}"
       project_name: "{{item.project}}"
       role_name: "{{item.role}}"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
     with_items:
       - { user: "nova", project: "service", role: "admin"}

--- a/roles/os-nova/tasks/nova_service_entities.yml
+++ b/roles/os-nova/tasks/nova_service_entities.yml
@@ -23,7 +23,7 @@
       service_name: "nova"
       service_type: "compute"
       description: "Nova Compute Service"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"
 
   - name: Create nova endpoints
     delegate_to: "{{ groups['openstack_identity'][0] }}"
@@ -42,4 +42,4 @@
           interface: "internal"
         - url: "http://{{ groups['openstack_compute_controller'][0] }}:8774/v2/%(tenant_id)s"
           interface: "admin"
-      endpoint: "http://{{ groups['openstack_identity'][0] }}:35357/v3"
+      endpoint: "http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3"

--- a/roles/os-nova/templates/neutron.conf.j2
+++ b/roles/os-nova/templates/neutron.conf.j2
@@ -8,8 +8,8 @@ rabbit_userid = openstack
 rabbit_password = {{ rabbitmq_password }}
 
 [keystone_authtoken]
-auth_uri = http://{{ groups['openstack_identity'][0] }}:5000
-auth_url = http://{{ groups['openstack_identity'][0] }}:35357
+auth_uri = http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}
+auth_url = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}
 auth_type = password
 project_domain_id = default
 user_domain_id = default

--- a/roles/os-nova/templates/nova.conf.j2
+++ b/roles/os-nova/templates/nova.conf.j2
@@ -23,8 +23,8 @@ rabbit_userid = {{ rabbitmq_username }}
 rabbit_password = {{ rabbitmq_password }}
 
 [keystone_authtoken]
-auth_uri = http://{{ groups['openstack_identity'][0] }}:5000
-auth_url = http://{{ groups['openstack_identity'][0] }}:35357
+auth_uri = http://{{ groups['openstack_identity'][0] }}:{{keystone_public_port}}
+auth_url = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}
 auth_type = password
 project_domain_id = default
 user_domain_id = default
@@ -46,7 +46,7 @@ api_servers = http://{{ groups['openstack_image'][0] }}:9292
 
 [neutron]
 url = http://{{ groups['openstack_networking'][0] }}:9696
-auth_url = http://{{ groups['openstack_identity'][0] }}:35357/v3
+auth_url = http://{{ groups['openstack_identity'][0] }}:{{keystone_admin_port}}/v3
 auth_type = password
 auth_strategy = keystone
 project_domain_name = Default


### PR DESCRIPTION
- Sometimes non-standard ports like 35357 and 5000 are blocked on the
  firewall. This patch creates keystone_admin_port and keystone_user_port
  variables with default values of 35357 and 5000 to permit the user to
  deploy keystone on another port.
