### PR TITLE
Add creation of systemd configuration files directory

### DIFF
--- a/roles/ciao-common/tasks/main.yml
+++ b/roles/ciao-common/tasks/main.yml
@@ -20,3 +20,6 @@
 
   - name: create /var/lib/ciao
     file: path=/var/lib/ciao state=directory owner=ciao group=ciao
+
+  - name: Create Systemd configuration directory
+    file: path=/etc/systemd/system state=directory mode=640


### PR DESCRIPTION
Add cretion of directory for configuration files of ciao-compute,
otherwise it could fail when trying to create the .service unit

Signed-off-by: Leoswaldo Macias leoswaldo.macias@intel.com
