### PR TITLE
os-cinder: Fix ssl certs path

### DIFF
--- a/roles/os-cinder/handlers/main.yml
+++ b/roles/os-cinder/handlers/main.yml
@@ -17,7 +17,6 @@
     service: name={{ item }} enabled=yes state=restarted
     with_items:
       - uwsgi@cinder-api.service
-      - memcached
       - cinder-scheduler
     when: inventory_hostname in groups['openstack_block_storage_controller']
 

--- a/roles/os-cinder/tasks/cinder_certificates.yml
+++ b/roles/os-cinder/tasks/cinder_certificates.yml
@@ -26,7 +26,7 @@
 
   - name: Copy certificate and key
     delegate_to: "{{ groups['openstack_identity'][0] }}"
-    synchronize: src=/etc/keystone/ssl/{{ item }} dest=/etc/cinder/ssl
+    synchronize: src=/etc/keystone/ssl/server/{{ item }} dest=/etc/cinder/ssl
     with_items:
       - "{{ cinder_hostname }}.cert.pem"
       - "{{ cinder_hostname }}.key.pem"


### PR DESCRIPTION
- Add /etc/keystone/ssl/server as a certificates path.
- Remove memcached from handlers
