### PR TITLE
os-swift: enable https endpoint

### DIFF
--- a/roles/os-swift/defaults/main.yml
+++ b/roles/os-swift/defaults/main.yml
@@ -17,3 +17,8 @@ ring_conf_files:
   - account.ring.gz
   - container.ring.gz
   - object.ring.gz
+
+swift_fqdn: "{{ hostvars[groups['openstack_object_storage_controller']]['ansible_fqdn'] }}"
+swift_p12password: "{{ keystone_p12password }}"
+swift_hostname: "{{ swift_fqdn.split('.')|first }}"
+swift_subject: "/DC={{swift_fqdn.split('.')[1:]|reverse|join('/DC=')}}/CN={{swift_fqdn}}/"

--- a/roles/os-swift/tasks/swift_certificates.yml
+++ b/roles/os-swift/tasks/swift_certificates.yml
@@ -1,0 +1,38 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - name: Create swift ssl directory
+    file: path=/etc/swift/ssl state=directory
+
+  - name: Create a swift Server Cert
+    certificate:
+      cadir: "/etc/keystone/ssl"
+      hostname: "{{ swift_hostname }}"
+      subj: "{{ swift_subject }}"
+      p12password: "{{ swift_p12password }}"
+    delegate_to: "{{ groups['openstack_identity'][0] }}"
+
+  - synchronize: src="{{ item }}" dest=/etc/swift/ssl/
+    delegate_to: "{{ groups['openstack_identity'][0] }}"
+    with_items:
+        - "/etc/keystone/ssl/server/{{ swift_hostname }}.key.pem"
+        - "/etc/keystone/ssl/server/{{ swift_hostname }}.cert.pem"
+
+  - name: Retrieve CA certificate
+    delegate_to: "{{ groups['openstack_identity'][0] }}"
+    synchronize: src=/etc/keystone/ssl/cacert.pem dest=/etc/swift
+
+  - name: Ensure proper permissions of CA cert
+    file: path=/etc/swift/cacert.pem owner=swift group=swift mode=400

--- a/roles/os-swift/tasks/swift_configure_controller.yml
+++ b/roles/os-swift/tasks/swift_configure_controller.yml
@@ -22,12 +22,15 @@
     template: dest=/etc/swift/proxy-server.conf src=proxy-server.conf.j2 owner=root group=swift mode=660
     notify: restart swift controller node services
 
-  - name: Retrieve the certificate
-    delegate_to: "{{ groups['openstack_identity'][0] }}"
-    synchronize: src=/etc/keystone/ssl/cacert.pem dest=/etc/swift
+  - include: swift_certificates.yml
 
-  - name: Ensure proper permissions of the certificate
-    file: path=/etc/swift/cacert.pem owner=swift group=swift mode=400
+  - name: Create /etc/nginx directory
+    file: path=/etc/nginx state=directory
+    
+  - name: Crete Swift nginx config file
+    delegate_to: "{{ groups['openstack_object_storage_controller'][0] }}"
+    template: dest=/etc/nginx/swift-proxy.conf src=nginx-swift-proxy.conf.j2
+    notify: restart nginx
 
   # Create the builders
   # Accounting builder

--- a/roles/os-swift/tasks/swift_service_entities.yml
+++ b/roles/os-swift/tasks/swift_service_entities.yml
@@ -37,11 +37,11 @@
       service_name: "swift"
       service_type: "object-store"
       endpoint_list:
-        - url: "http://{{ groups['openstack_object_storage_controller'][0] }}:8080/v1/AUTH_%(tenant_id)s"
+        - url: "https://{{ swift_fqdn }}:8080/v1/AUTH_%(tenant_id)s"
           interface: "public"
-        - url: "http://{{ groups['openstack_object_storage_controller'][0] }}:8080/v1/AUTH_%(tenant_id)s"
+        - url: "https://{{ swift_fqdn }}:8080/v1/AUTH_%(tenant_id)s"
           interface: "internal"
-        - url: "http://{{ groups['openstack_object_storage_controller'][0] }}:8080/v1"
+        - url: "https://{{ swift_fqdn }}:8080/v1"
           interface: "admin"
       endpoint: "https://{{ keystone_fqdn }}:{{keystone_admin_port}}/v3"
       insecure: yes

--- a/roles/os-swift/templates/nginx-swift-proxy.conf.j2
+++ b/roles/os-swift/templates/nginx-swift-proxy.conf.j2
@@ -1,0 +1,14 @@
+server {
+       listen 8080 ssl;
+       server_name {{ swift_fqdn }};
+       ssl_certificate /etc/swift/ssl/{{ swift_hostname }}.cert.pem;
+       ssl_certificate_key /etc/swift/ssl/{{ swift_hostname }}.key.pem;
+
+       location / {
+                  proxy_set_header  Host $host;
+                  proxy_set_header  X-Real-IP $remote_addr;
+                  proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header  X-Forwarded-Proto $scheme;
+                  proxy_pass        http://127.0.0.1:8081;
+       }
+}

--- a/roles/os-swift/templates/proxy-server.conf.j2
+++ b/roles/os-swift/templates/proxy-server.conf.j2
@@ -3,7 +3,8 @@
 debug = True
 {% endif %}
 
-bind_port = 8080
+bind_ip = 127.0.0.1
+bind_port = 8081
 user = swift
 swift_dir = /etc/swift
 


### PR DESCRIPTION
- Enforce SSL connections from openstack clients to swift proxy
