### PR TITLE
Add datastore paths in ciao-controller command

### DIFF
--- a/roles/ciao-controller/templates/ciao-controller.service.j2
+++ b/roles/ciao-controller/templates/ciao-controller.service.j2
@@ -13,6 +13,8 @@ ExecStart=/usr/bin/ciao-controller --cacert=/etc/pki/ciao/CAcert-{{ groups['ciao
                                    --workloads_path=/var/lib/ciao/workloads \
                                    --httpskey /etc/keystone/ssl/server/{{ansible_hostname}}.key.pem \
                                    --httpscert /etc/keystone/ssl/server/{{ansible_hostname}}.cert.pem \
+				   --database_path=/var/lib/ciao/datastore/ciao-controller.db \
+				   --stats_path=/var/lib/ciao/datastore/ciao-controller-stats.db \
                                    --logtostderr -v 2
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Database files were saved at ./ and /tmp by default https://github.com/01org/ciao/blob/master/ciao-controller/main.go#L55-56 . They should be created at other data dir as it is proposed in PR
`
/var/lib/ciao/datastore
`

Signed-off-by: Munoz, Obed N obed.n.munoz@intel.com
