### PR TITLE
os-cinder: Support a list of devices for lvm setup

### DIFF
--- a/roles/os-cinder/README.md
+++ b/roles/os-cinder/README.md
@@ -12,6 +12,17 @@ where this role can create the users, roles, etc.
 All variables of this role are defined in `defaults/main.yml`
 
 ## Mandatory variables
+* `cinder_devices` *This is a list of devices*
+
+  ```
+    Example:
+
+    cinder_devices:
+      - /dev/sdb
+      - /dev/sdc
+      - /dev/sdd
+      - /dev/sdf
+  ```
 * `cinder_user_password`
 * `cinder_database_password`
 

--- a/roles/os-cinder/defaults/main.yml
+++ b/roles/os-cinder/defaults/main.yml
@@ -19,3 +19,10 @@ cinder_hostname: "{{ cinder_fqdn.split('.')|first }}"
 cinder_subject: "/DC={{cinder_fqdn.split('.')[1:]|reverse|join('/DC=')}}/CN={{cinder_fqdn}}/"
 
 cinder_public_interface_name: "{{ ansible_default_ipv4['interface'] }}"
+
+### The following variable can be used to specify the list ###
+### of devices to assign to cinder.                        ###
+#cinder_devices:
+#  - /dev/sdb
+#  - /dev/sbc
+#  - /dev/sdd

--- a/roles/os-cinder/handlers/main.yml
+++ b/roles/os-cinder/handlers/main.yml
@@ -23,6 +23,5 @@
   - name: restart cinder storage
     service: name={{ item }} enabled=yes state=restarted
     with_items:
-      - tgtd
       - cinder-volume
-    when: inventory_hostname in groups['openstack_block_storage_controller']
+    when: inventory_hostname in groups['openstack_block_storage']

--- a/roles/os-cinder/tasks/cinder_configure_common.yml
+++ b/roles/os-cinder/tasks/cinder_configure_common.yml
@@ -20,4 +20,5 @@
     template: dest=/etc/cinder/cinder.conf
               src=cinder.conf.j2 group=cinder mode=640
     notify:
+      - restart cinder controller
       - restart cinder storage

--- a/roles/os-cinder/tasks/cinder_configure_lvm.yml
+++ b/roles/os-cinder/tasks/cinder_configure_lvm.yml
@@ -13,16 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  - include: install_cinder_controller.yml
-    when: inventory_hostname in groups['openstack_block_storage_controller']
+- name: Setup LVM
+  lvg: vg=cinder-volumes pvs={{ cinder_devices }}
 
-  - include: install_cinder.yml
-    when: inventory_hostname in groups['openstack_block_storage']
+- name: Ensure Cinder storage services are running
+  service: name={{ item }} enabled=yes state=started
+  with_items:
+    - cinder-volume
+    - tgtd
+    - iscsid
 
-  - include: cinder_configure_common.yml
-
-  - include: cinder_controller.yml
-    when: inventory_hostname in groups['openstack_block_storage_controller']
-
-  - include: cinder_configure_lvm.yml
-    when: inventory_hostname in groups['openstack_block_storage']
+- meta: flush_handlers

--- a/roles/os-cinder/tasks/cinder_controller.yml
+++ b/roles/os-cinder/tasks/cinder_controller.yml
@@ -33,7 +33,6 @@
   - name: Create cinder configuration for nginx
     template: dest=/etc/nginx/cinder.conf src=nginx-cinder.conf.j2
     notify:
-      - restart cinder controller
       - restart nginx
 
   - name: Ensure Cinder is running
@@ -41,5 +40,4 @@
     with_items:
       - nginx
       - uwsgi@cinder-api.socket
-
-  - meta: flush_handlers
+      - cinder-scheduler


### PR DESCRIPTION
```
In order to setup cinder, now a list of devices must be provided. It allows
to clear-config-management to handle the lvm setup.
```
