### PR TITLE
ciao-controller: Create compute service and endpoint for OpenStack

### DIFF
--- a/examples/ciao/group_vars/all
+++ b/examples/ciao/group_vars/all
@@ -14,15 +14,3 @@ ciao_admin_email: admin@example.com
 ciao_cert_organization: Example, Inc.
 ciao_guest_user: demouser
 ciao_guest_key: ~/.ssh/id_rsa.pub
-
-keystone_services:
-  - service_name: "ciao"
-    service_type: "compute"
-keystone_users:
-  - user_name: "{{ ciao_service_user }}"
-    password: "{{ ciao_service_password }}"
-    project_name: "admin"
-keystone_user_roles:
-  - user_name: "{{ ciao_service_user }}"
-    project_name: service
-    role_name: admin

--- a/roles/ciao-controller/tasks/create_endpoints.yml
+++ b/roles/ciao-controller/tasks/create_endpoints.yml
@@ -1,0 +1,75 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create CIAO Compute Service for OpenStack
+  delegate_to: "{{ keystone_fqdn }}"
+  keystone:
+    login_user: admin
+    login_password: "{{ keystone_admin_password }}"
+    login_project_name: "admin"
+    command: "ensure_service"
+    service_name: "ciao"
+    service_type: "compute"
+    description: "CIAO Compute Service"
+    endpoint: "https://{{ keystone_fqdn }}:{{ keystone_admin_port }}/v3"
+    insecure: yes
+
+- name: Create Compute Service Endpoint in OpenStack
+  delegate_to: "{{ keystone_fqdn }}"
+  keystone:
+    login_user: admin
+    login_password: "{{ keystone_admin_password }}"
+    login_project_name: "admin"
+    command: "ensure_endpoint"
+    region_name: "RegionOne"
+    service_name: "ciao"
+    service_type: "compute"
+    endpoint_list:
+      - url: "https://{{ ciao_controller_fqdn }}:8774/v2.1/%(tenant_id)s"
+        interface: "public"
+      - url: "https://{{ ciao_controller_fqdn }}:8774/v2.1/%(tenant_id)s"
+        interface: "internal"
+      - url: "https://{{ ciao_controller_fqdn }}:8774/v2.1/%(tenant_id)s"
+        interface: "admin"
+    endpoint: "https://{{ keystone_fqdn }}:{{ keystone_admin_port }}/v3"
+    insecure: yes
+
+- name: Create CIAO service user for OpenStack
+  delegate_to: "{{ keystone_fqdn }}"
+  keystone:
+    login_user: admin
+    login_password: "{{ keystone_admin_password }}"
+    login_project_name: "admin"
+    command: "ensure_user"
+    user_name: "{{ ciao_service_user }}"
+    project_name: "service"
+    password: "{{ ciao_service_password }}"
+    domain_name: "Default"
+    email: "{{ ciao_admin_email }}"
+    endpoint: "https://{{ keystone_fqdn }}:{{ keystone_admin_port }}/v3"
+    insecure: yes
+
+- name: Add CIAO service user to admin role
+  delegate_to: "{{ keystone_fqdn }}"
+  keystone:
+    login_user: admin
+    login_password: "{{ keystone_admin_password }}"
+    login_project_name: "admin"
+    command: "ensure_user_role"
+    user_name: "{{ ciao_service_user }}"
+    project_name: "service"
+    role_name: "admin"
+    endpoint: "https://{{ keystone_fqdn }}:{{ keystone_admin_port }}/v3"
+    insecure: yes

--- a/roles/ciao-controller/tasks/main.yml
+++ b/roles/ciao-controller/tasks/main.yml
@@ -17,4 +17,5 @@
   - include: create_certs.yml
   - include: setup_certs.yml
   - include: start_services.yml
+  - include: create_endpoints.yml
   - include: ciaorc.yml


### PR DESCRIPTION
Rally needs a compute endpoint in order to run.
- Create ciao admin user in openstack by default
- Create ciao compute service in openstack by default
- Create ciao compute endpoint in openstack by default
- Remove optional variables in example playbook to create
  the items above.

Fixes #14

Signed-off-by: Alberto Murillo alberto.murillo.silva@intel.com
