### PR TITLE
examples/ciao: use consistent domains for the `group_vars/all` file

### DIFF
--- a/examples/ciao/group_vars/all
+++ b/examples/ciao/group_vars/all
@@ -17,7 +17,7 @@ keystone_p12password: secret
 
 # Vars required for ciao-common
 # https://github.com/clearlinux/clear-config-management/tree/master/roles/ciao-common
-ciao_controller_fqdn: controller.intel.com
+ciao_controller_fqdn: controller.example.com
 
 # Vars required for ciao-controller
 # https://github.com/clearlinux/clear-config-management/tree/master/roles/ciao-controller


### PR DESCRIPTION
There were usage of different domains for some variables.
this commit use a single domain for better understanding of the setup.

Signed-off-by: Simental Magana, Marcos marcos.simental.magana@intel.com
