### PR TITLE
examples/ciao: remove duplicated `ciao_network` host

### DIFF
--- a/examples/ciao/hosts
+++ b/examples/ciao/hosts
@@ -12,6 +12,3 @@ network.example.com
 
 [ciao_compute]
 compute.example.com
-
-[ciao_network]
-network.example.com


### PR DESCRIPTION
the [ciao_network] group in `examples/ciao/hosts` is
duplicated. This commits removes duplication of such group.

Signed-off-by: Simental Magana, Marcos marcos.simental.magana@intel.com
