### PR TITLE
ciao-controller: Add a note on ciao_guest_{user,key}

### DIFF
--- a/roles/ciao-controller/README.md
+++ b/roles/ciao-controller/README.md
@@ -27,6 +27,8 @@ ciao_cert_organization | Example Inc. | Name of the organization running the CIA
 ciao_guest_user | demouser | CIAO virtual machines can be accessed with this username and it's public key
 ciao_guest_key | ~/.ssh/id_rsa.pub | A path to an SSH public authentication key for `ciao_guest_user`
 
+**WARNING**: `ciao_guest_user` and `ciao_guest_key` are a temporary development feature. They give the developer running a dev/test ciao cluster superuser ssh access to all compute workload instances and also all cnci instances. In the future this will be removed when cloud-init and user specified workloads are enabled in the webui and cli.
+
 ## Dependencies
 * [ciao-common](https://github.com/clearlinux/clear-config-management/tree/master/roles/ciao-common)
 * [os-common](https://github.com/clearlinux/clear-config-management/tree/master/roles/os-common)


### PR DESCRIPTION
These variables will setup access to ALL vm launched including
CNCI images.

This is a temporary solution for development/testing purposes
until a formal way to define per VM access from the user
perspective is available

Signed-off-by: Alberto Murillo alberto.murillo.silva@intel.com
