### PR TITLE
os-keystone: Add http/2 support for nginx

### DIFF
--- a/roles/os-keystone/templates/nginx-keystone.conf.j2
+++ b/roles/os-keystone/templates/nginx-keystone.conf.j2
@@ -1,5 +1,5 @@
 server {
-       listen {{ keystone_admin_port }} ssl;
+       listen {{ keystone_admin_port }} ssl {% 'http2' if http2 %};
        server_name {{ keystone_fqdn }};
        ssl_certificate /etc/keystone/ssl/server/{{ keystone_hostname }}.cert.pem;
        ssl_certificate_key /etc/keystone/ssl/server/{{ keystone_hostname }}.key.pem;
@@ -36,7 +36,7 @@ server {
 }
 
 server {
-       listen {{ keystone_public_port }} ssl;
+       listen {{ keystone_public_port }} ssl {% 'http2' if http2 %};
        server_name {{ keystone_fqdn }};
        ssl_certificate /etc/keystone/ssl/server/{{ keystone_hostname }}.cert.pem;
        ssl_certificate_key /etc/keystone/ssl/server/{{ keystone_hostname }}.key.pem;

--- a/roles/os-keystone/vars/Clear linux software for intel architecture.yml
+++ b/roles/os-keystone/vars/Clear linux software for intel architecture.yml
@@ -7,3 +7,4 @@ packages:
 
 http_user: httpd
 nginx_conf_dir: /etc/nginx
+http2: True

--- a/roles/os-keystone/vars/Debian.yml
+++ b/roles/os-keystone/vars/Debian.yml
@@ -8,3 +8,4 @@ packages:
 
 http_user: www-data
 nginx_conf_dir: /etc/nginx/conf.d
+http2: False


### PR DESCRIPTION
The support for the HTTP/2 were added as default for nginx.
- The openstack client and the ciao-cli works as expected with the new configuration update.
