### PR TITLE
examples/ciao: Update documentation

### DIFF
--- a/examples/ciao/README.md
+++ b/examples/ciao/README.md
@@ -1,33 +1,41 @@
 # Ansible roles for CIAO
-This is sample playbook to deploy CIAO using ansible.
+This is an example of a playbook to deploy CIAO using ansible.
 
+---
 ## Prework
 
 ### Access
-Ansible requires that the user running the playbook has passwordless ssh access to the managed nodes and sudo privileged.
+Ansible requires that the user running the playbook has passwordless ssh access to the managed nodes, sudo privileges and python installed on each node.
 
 ### Requirements
-The deployment machine require certain python modules and packages to be installed as they are requirements for ansible modules used in this playbook.
 
-#### Install Ansible
+#### CIAO nodes
+CIAO can be installed in ClearLinux, Fedora 24 and Ubuntu 16.04 and its dependencies will be installed automatically.
+
+#### Deployment machine
+The deployment machine can be any Linux OS as long as it has the following requirements installed.
+
+NOTE: In ClearLinux, all the requirements can be installed with the following bundles:
+
+    swupd bundle-add sysadmin-hostmgmt go-basic kvm-host python-openstack-clients os-core-dev
+
+###### Install Ansible
 The required version of ansible is 2.1 or later. Install ansible in your distribution as described in [Installing ansible](http://docs.ansible.com/ansible/intro_installation.html)
 
-##### Install ansible roles dependencies
+###### Install ansible roles dependencies
 This playbook make use of roles that requires extra dependencies. These dependencies are usually outdated in the OS package manager and is recomended to
 install them from pip.
 
     pip install netaddr docker-py python-keystoneclient
 
-#### Install Go
+###### Install Go
 To build ciao from sources the deployment machine requires golang to be installed. Install the latest release of go for your distribution as described in [Installing Go](https://golang.org/doc/install)
 
-#### Install qemu
+###### Install qemu
 qemu is required to create the cnci image. Use your distribution package manager
 to install the `qemu` package
 
-NOTE: In ClearLinux, all the dependencies can be installed with the following bundles
-
-    swupd bundle-add sysadmin-hostmgmt go-basic kvm-host python-openstack-clients os-core-dev
+---
 
 ## Configuration
 
@@ -36,9 +44,8 @@ Install the required roles from ansible-galaxy
 
     ansible-galaxy install -r requirements.yml
 
-### Edit the hosts file according to your cluster setup
-hosts.yml
-```
+### Edit the [hosts](hosts) file according to your cluster setup
+```ini
 [controllers]
 controller.example.com
 
@@ -51,8 +58,12 @@ compute2.example.com
 compute3.example.com
 ```
 
-Optionally edit `group_vars/all` file to change default passwords and other settings
+Optionally edit [group_vars/all](group_vars/all) file to change default passwords and other settings
+
+---
 
 ### Run the playbook
 
     ansible-playbook -i hosts ciao.yml
+
+Note: In order to deploy ciao from the latest development branch set `ciao_dev = True` in [group_vars/all](group_vars/all) file or pass the command line argument `--extra-vars "ciao_dev=true"`


### PR DESCRIPTION
- Specify python is required on managed nodes
- Differentiate ciao nodes dependencies and deployment machine dependencies
- Mention ciao_dev can be used to deploy from source code.

Signed-off-by: Alberto Murillo alberto.murillo.silva@intel.com
