### PR TITLE
Enable scp for fedora 24

### DIFF
--- a/examples/ciao/ansible.cfg
+++ b/examples/ciao/ansible.cfg
@@ -4,3 +4,4 @@
 
 [ssh_connection]
 pipelining = True
+scp_if_ssh = True


### PR DESCRIPTION
Sftp fails to copy some files on fedora 24. Using scp the files can
be copied, This commit adds "scp_if_ssh" in ansible.conf.

Signed-off-by: Jesus Ornelas Aguayo jesus.ornelas.aguayo@intel.com
