### PR TITLE
ciao: create admin-openrc and demo-openrc

### DIFF
--- a/examples/ciao/cleanup/ciao.yml
+++ b/examples/ciao/cleanup/ciao.yml
@@ -6,7 +6,8 @@
       local_action: file path={{ item }} state=absent
       with_items:
         - ./openrc
-        - ./ciaorc
+        - ./admin-ciaorc
+        - ./demo-ciaorc
         - ./clouds.yaml
         - ./certificates
         - ./images/clear-8260-ciao-networking.img

--- a/roles/ciao-controller/tasks/main.yml
+++ b/roles/ciao-controller/tasks/main.yml
@@ -49,4 +49,7 @@
   - name: Create ciaorc file
     become: no
     connection: local
-    template: src=ciaorc.j2 dest=./ciaorc mode=0400
+    template: src={{ item }}.j2 dest=./{{ item }} mode=0400
+    with_items:
+      - admin-ciaorc
+      - demo-ciaorc

--- a/roles/ciao-controller/templates/admin-ciaorc.j2
+++ b/roles/ciao-controller/templates/admin-ciaorc.j2
@@ -1,0 +1,5 @@
+export CIAO_CONTROLLER={{ keystone_fqdn }}
+export CIAO_IDENTITY=https://{{ keystone_fqdn }}:35357
+export CIAO_USERNAME=admin
+export CIAO_PASSWORD={{ keystone_admin_password }}
+export CIAO_TENANT_NAME=admin

--- a/roles/ciao-controller/templates/ciaorc.j2
+++ b/roles/ciao-controller/templates/ciaorc.j2
@@ -1,4 +1,0 @@
-export CIAO_CONTROLLER={{ keystone_fqdn }}
-export CIAO_IDENTITY=https://{{ keystone_fqdn }}:35357
-export CIAO_USERNAME={{ ciao_service_user }}
-export CIAO_PASSWORD={{ ciao_service_password }}

--- a/roles/ciao-controller/templates/demo-ciaorc.j2
+++ b/roles/ciao-controller/templates/demo-ciaorc.j2
@@ -1,0 +1,5 @@
+export CIAO_CONTROLLER={{ keystone_fqdn }}
+export CIAO_IDENTITY=https://{{ keystone_fqdn }}:35357
+export CIAO_USERNAME={{ keystone_users[0].user }}
+export CIAO_PASSWORD={{ keystone_users[0].password }}
+export CIAO_TENANT_NAME=demo


### PR DESCRIPTION
The playbooks were creating a ciaorc to authenticate the cli
with the ciao user.

The ciao user is reserved for ciao services authenticating into keystone
and should not be used in the cli to create instances.

This changes creates admin-openrc with credentials for the admin user
and demo-openrc with credentials for the demo user to be used by ciao-cli.

Fixes #46

Signed-off-by: Alberto Murillo alberto.murillo.silva@intel.com
