### PR TITLE
ciao-common: Create /etc/systemd/system

### DIFF
--- a/roles/ciao-common/tasks/main.yml
+++ b/roles/ciao-common/tasks/main.yml
@@ -22,7 +22,7 @@
       system: yes
     when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"
 
-  - name: Create /var/lib/ciao tree
+  - name: Create directories required by ciao
     file: path={{ item }} state=directory owner=ciao group=ciao
     with_items:
       - /var/lib/ciao
@@ -32,6 +32,7 @@
       - /etc/pki
       - /etc/pki/ciao
       - /etc/pki/keystone
+      - /etc/systemd/system
 
   - name: Set bindir location
     set_fact: bindir={{ '/usr/local/bin' if ciao_dev else '/usr/bin' }}


### PR DESCRIPTION
ciao creates systemd unit files to start ciao services.

In the case of ClearLinux, there is the possibility that
/etc/systemd/system has not been created yet. This change
ensures /etc/systemd/system is present before trying to
create unit files there.

Fixes #53

Signed-off-by: Alberto Murillo alberto.murillo.silva@intel.com
