### PR TITLE
ciao: Change default value for gopath

### DIFF
--- a/examples/ciao/cleanup/ciao.yml
+++ b/examples/ciao/cleanup/ciao.yml
@@ -11,8 +11,8 @@
         - ./clouds.yaml
         - ./certificates
         - ./images/clear-8260-ciao-networking.img
-        - ~/go
         - ./fetch
+        - /tmp/go
 
 - hosts: controllers
   become: yes

--- a/roles/ciao-common/README.md
+++ b/roles/ciao-common/README.md
@@ -10,7 +10,7 @@ The following variables are available for all ciao roles
 Variable  | Default Value | Description
 --------  | ------------- | -----------
 ciao_dev | False | Set to True to install from source, otherwise install form OS packages
-gopath | ~/go | golang GOPATH
+gopath | /tmp/go | golang GOPATH
 ciao_controller_fqdn | `{{ ansible_fqdn }}` | FQDN for CIAO controller node
 cnci_image_url | [clear-8260-ciao-networking.img.xz](https://download.clearlinux.org/demos/ciao/clear-8260-ciao-networking.img.xz) | URL for the latest ciao networking image
 ovmf_url | [OVMF.fd](https://download.clearlinux.org/image/OVMF.fd) | EFI firmware required for CNCI Image.

--- a/roles/ciao-common/defaults/main.yml
+++ b/roles/ciao-common/defaults/main.yml
@@ -18,7 +18,7 @@
 ciao_dev: False
 
 # golang GOPATH
-gopath: ~/go
+gopath: /tmp/go
 
 # Fully Qualified Domain Name for CIAO controller node
 ciao_controller_fqdn: "{{ hostvars[groups['controllers'][0]]['ansible_fqdn'] }}"


### PR DESCRIPTION
Using $GOPATH as the value for gopath is not
so easily achievable because the GOPATH value
for the deployment machine does not get copied
automatically to other nodes.

Also setting a fact on one node does not set it
on other nodes.

The easiest way to share this value across the
different ciao roles is to set it as a variable
that can be overriden in groups_vars/all file or
via the cmdline with --extra-vars "gopath=$GOPATH"

Fixes: #57

Signed-off-by: Alberto Murillo alberto.murillo.silva@intel.com
