### PR TITLE
[DONOTMERGE] ansible: Add ciao-image role

### DIFF
--- a/roles/ciao-common/defaults/main.yml
+++ b/roles/ciao-common/defaults/main.yml
@@ -23,6 +23,9 @@ gopath: /tmp/go
 # Fully Qualified Domain Name for CIAO controller node
 ciao_controller_fqdn: "{{ hostvars[groups['controllers'][0]]['ansible_fqdn'] }}"
 
+# Fully Qualified Domain Name for CIAO Image node
+ciao_image_fqdn: "{{ ansible_fqdn }}"
+
 # URL for the latest ciao networking image
 cnci_image_url: https://download.clearlinux.org/demos/ciao/clear-8260-ciao-networking.img.xz
 

--- a/roles/ciao-controller/defaults/main.yml
+++ b/roles/ciao-controller/defaults/main.yml
@@ -56,6 +56,9 @@ ciao_openstack_services:
   - service: cinderv2
     type: volumev2
     description: CIAO Storage Service v2
+  - service: glance
+    type: image
+    description: CIAO Image Service
 
 # CIAO endpoints to create in Keystone
 ciao_openstack_endpoints:
@@ -74,6 +77,11 @@ ciao_openstack_endpoints:
     public_url: https://{{ ciao_controller_fqdn }}:8776/v2/%(tenant_id)s
     internal_url: https://{{ ciao_controller_fqdn }}:8776/v2/%(tenant_id)s
     admin_url: https://{{ ciao_controller_fqdn }}:8776/v2/%(tenant_id)s
+  - service: glance
+    type: image
+    public_url: https://{{ ciao_image_fqdn }}:9292
+    internal_url: https://{{ ciao_controller_fqdn }}:9292
+    admin_url: https://{{ ciao_controller_fqdn }}:9292
 
 # Cephx user to authenticate
 ceph_id: admin

--- a/roles/ciao-controller/tasks/certificates.yml
+++ b/roles/ciao-controller/tasks/certificates.yml
@@ -32,6 +32,36 @@
       chdir: certificates/ciao
       creates: CAcert-{{ ciao_controller_fqdn }}.pem
 
+  - name: Create a local keystone certificates directory if it does not exist
+    become: no
+    local_action: file path=certificates/keystone state=directory
+
+  - name: Create keystone self-signed certificate and key
+    become: no
+    local_action: >
+      command
+      openssl req -new -nodes -x509 -subj "/CN={{ keystone_fqdn }}" -days 365
+      -keyout certificates/keystone/keystone_key.pem
+      -out certificates/keystone/keystone_cert.pem -extensions v3_ca
+    args:
+      creates: certificates/keystone/keystone_cert.pem
+
+  - name: Create ciao image self-signed SSL cert
+    become: no
+    local_action: >
+      command
+      openssl req -new -nodes -x509 -subj "/CN={{ ciao_image_fqdn }}" -days 365
+      -keyout certificates/ciao/ciao-image-key.pem
+      -out certificates/ciao/ciao-image-cacert.pem -extensions v3_ca
+    args:
+      creates: certificates/ciao/ciao-image-cacert.pem
+
+  - set_fact:
+      keystone_cert: "{{ lookup('file', 'certificates/keystone/keystone_cert.pem') }}"
+
+  - name: Append keystone cert to ciao_image.cert.pem
+    lineinfile: dest={{ playbook_dir }}/certificates/ciao/ciao-image-cacert.pem line="{{ keystone_cert }}"
+
   - name: Create agent keys
     become: no
     connection: local

--- a/roles/ciao-image/LICENSE
+++ b/roles/ciao-image/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/roles/ciao-image/README.md
+++ b/roles/ciao-image/README.md
@@ -1,0 +1,43 @@
+# clearlinux.ciao-image
+Ansible role to install the image service for a CIAO cluster
+
+This role configures the following components
+
+* ciao image
+
+## Requirements
+None
+
+## Role Variables
+The available variables for this roles are the variables from [clearlinux.ciao-image](https://github.com/clearlinux/ansible-role-ciao-image) plus the following:
+
+Note: Mandatory variables are shown in **bold**
+
+Variable  | Default Value | Description
+--------  | ------------- | -----------
+ciao_image_fqdn | `{{ ansible_fqdn }}` | Fully Qualified Domain Name of the CIAO Image node
+
+## Dependencies
+* [clearlinux.ciao-common](https://github.com/clearlinux/ansible-role-ciao-common)
+
+## Example Playbook
+file *ciao.yml*
+```
+- hosts: image
+  roles:
+    - clearlinux.ciao-image
+```
+
+file *group_vars/all*
+```
+ciao_image_fqdn: image.example.com
+```
+
+## Contribution
+**Pull Requests and Issues should be opened at [clearlinux/clear-config-management](https://github.com/clearlinux/clear-config-management).**
+
+## License
+Apache-2.0
+
+## Author Information
+This role was created by [Erick Cardona](erick.cardona.ruiz@intel.com)

--- a/roles/ciao-image/defaults/main.yml
+++ b/roles/ciao-image/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/roles/ciao-image/handlers/main.yml
+++ b/roles/ciao-image/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - name: restart image
+    service: name=ciao-image.service enabled=yes state=restarted

--- a/roles/ciao-image/meta/main.yml
+++ b/roles/ciao-image/meta/main.yml
@@ -1,0 +1,25 @@
+galaxy_info:
+  author: Erick Cardona
+  description: Ansible role to install the image service for a CIAO cluster
+  company: Intel
+
+  issue_tracker_url: https://github.com/clearlinux/clear-config-management
+
+  license: Apache
+
+  min_ansible_version: 2.1
+
+  platforms:
+  - name: Ubuntu
+    versions:
+      - xenial
+  - name: ClearLinux
+
+  galaxy_tags:
+    - ubuntu
+    - xenial
+    - clearlinux
+    - ciao
+
+dependencies:
+  - clearlinux.ciao-common

--- a/roles/ciao-image/tasks/certificates.yml
+++ b/roles/ciao-image/tasks/certificates.yml
@@ -1,0 +1,50 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - name: Copy ciao-image certificates
+    copy: src={{ item.src }} dest={{ item.dest }}
+    with_items:
+      - src: certificates/ciao/ciao-image-key.pem
+        dest: /etc/pki/ciao/ciao-image-key.pem
+      - src: certificates/ciao/ciao-image-cacert.pem
+        dest: /etc/pki/ciao/ciao-image-cacert.pem
+
+  - name: Install certificate (ClearLinux)
+    copy: src=certificates/keystone/keystone_cert.pem dest=/etc/ssl/certs
+    when: ansible_os_family == "Clear linux software for intel architecture"
+
+  - name: Install certificate (Ubuntu)
+    copy:
+      src: certificates/ciao/ciao-image-cacert.pem
+      dest: /usr/local/share/ca-certificates/ciao-image-cacert.crt
+    when: ansible_os_family == "Debian"
+
+  - name: Update CA certificates (Ubuntu)
+    command: update-ca-certificates
+    args:
+      creates: /etc/ssl/certs/ciao-image-cacert.pem
+    when: ansible_os_family == "Debian"
+
+  - name: Install certificate (Fedora)
+    copy:
+      src: certificates/ciao/ciao-image-cacert.pem
+      dest: /etc/pki/ca-trust/source/anchors/ciao-image-cacert.pem
+    when: ansible_os_family == "RedHat"
+
+  - name: Update CA trust (Fedora)
+    command: update-ca-trust
+    args:
+      creates: /etc/pki/tls/certs/ciao-image-cacert.pem
+    when: ansible_os_family == "RedHat"

--- a/roles/ciao-image/tasks/install.yml
+++ b/roles/ciao-image/tasks/install.yml
@@ -1,0 +1,20 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - name: Copy CIAO image Binary
+    copy: src={{ gopath }}/bin/{{ item }} dest={{ bindir }}/{{ item }} mode=755
+    with_items:
+      - ciao-image
+    when: ciao_dev

--- a/roles/ciao-image/tasks/main.yml
+++ b/roles/ciao-image/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - include: install.yml
+  - include: certificates.yml
+  - include: startservice.yml

--- a/roles/ciao-image/tasks/startservice.yml
+++ b/roles/ciao-image/tasks/startservice.yml
@@ -1,0 +1,27 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - name: Create ciao image unit
+    template: src=ciao-image.service.j2 dest=/etc/systemd/system/ciao-image.service
+    notify:
+      - reload systemd config
+      - restart image
+
+  - meta: flush_handlers
+
+  - name: Ensure ciao image service is running
+    service: name={{ item }} enabled=yes state=started
+    with_items:
+      - ciao-image.service

--- a/roles/ciao-image/templates/ciao-image.service.j2
+++ b/roles/ciao-image/templates/ciao-image.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=CIAO Image Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={{ bindir }}/ciao-image -identity=https://{{ keystone_fqdn }}:35357 \
+                                  -logtostderr -v=3
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
[RFC]
TESTED IN FEDORA 24 and ClearLinux

This role enables the ciao-image service.
- Add glance endpoints in the keystone node
- Setup the ciao-image service
