### PR TITLE
ciao-controller: explicitly specify local tasks for build.

### DIFF
--- a/roles/ciao-controller/tasks/build.yml
+++ b/roles/ciao-controller/tasks/build.yml
@@ -16,18 +16,21 @@
   - block:
       - name: Setup GOROOT directory
         file: path={{ gopath }} state=directory
+        connection: local
 
       - name: Build CIAO from sources
         shell: go get -v github.com/01org/ciao/...
         register: ciao_build
         async: 1800
         poll: 0
+        connection: local
         environment:
           GOPATH: "{{ gopath }}"
     when: ciao_dev
 
   - block:
       - name: Create fetch directory
+        connection: local
         file: path=fetch state=directory
 
       - name: Fetch ciao files
@@ -42,6 +45,7 @@
 
       - name: Make ciao files runnable
         file: path=./fetch/{{ item }} mode=0755
+        connection: local
         with_items:
           - ciao-cert
           - ciao-cnci-agent

--- a/roles/ciao-controller/tasks/main.yml
+++ b/roles/ciao-controller/tasks/main.yml
@@ -15,7 +15,6 @@
 
   - include: build.yml
     become: no
-    connection: local
 
   - include: images.yml
     become: no


### PR DESCRIPTION
Before this commit, all build tasks for the ciao-controller
role were perfomed as `connection: local`, this is handy
but not accurate (e.g: "Fetch ciao files" shouldn't be local).

This commit specifies which tasks in build should be
performed as local, instead of the whole build.yml playbook.

Signed-off-by: Simental Magana, Marcos marcos.simental.magana@intel.com
