### PR TITLE
ciao-compute,  ciao-network: remove the strategy free feature

### DIFF
--- a/examples/ciao/ciao_computes.yml
+++ b/examples/ciao/ciao_computes.yml
@@ -1,6 +1,5 @@
 ---
   - hosts: computes
     become: yes
-    strategy: free
     roles:
       - clearlinux.ciao-compute

--- a/examples/ciao/ciao_networks.yml
+++ b/examples/ciao/ciao_networks.yml
@@ -1,6 +1,5 @@
 ---
   - hosts: networks
     become: yes
-    strategy: free
     roles:
       - clearlinux.ciao-network


### PR DESCRIPTION
The strategy free was causing some weird behaviour when running parallel tasks.
Returning to the default execution strategy fix this.

Closes https://github.com/clearlinux/clear-config-management/issues/72
