### PR TITLE
ciao-controller: remove nbd usage, using loops instead.

### DIFF
--- a/examples/ciao/README.md
+++ b/examples/ciao/README.md
@@ -23,7 +23,7 @@ The deployment machine can be any Linux OS as long as it has the following requi
 
 NOTE: In ClearLinux, all the requirements can be installed with the following bundles:
 
-    sudo swupd bundle-add sysadmin-hostmgmt go-basic kvm-host python-openstack-clients os-core-dev
+    sudo swupd bundle-add sysadmin-hostmgmt go-basic python-openstack-clients os-core-dev
 
 ###### Install Ansible
 The required version of ansible is 2.1 or later. Install ansible in your distribution as described in [Installing ansible](http://docs.ansible.com/ansible/intro_installation.html)
@@ -38,10 +38,6 @@ are usually outdated in the OS package manager and is recommended to install the
 To build ciao from sources the deployment machine requires golang to be installed.
 Install the latest release of go for your distribution as described in
 [Installing Go](https://golang.org/doc/install)
-
-###### Install qemu
-qemu is required to create the cnci image. Use your distribution package manager
-to install the `qemu` package
 
 ---
 

--- a/roles/ciao-controller/tasks/create_cnci_image.yml
+++ b/roles/ciao-controller/tasks/create_cnci_image.yml
@@ -41,29 +41,21 @@
     changed_when: False
 
   - block:
-    - name: Loading nbd module
-      become: yes
-      modprobe: name=nbd state=present params="max_part=63"
 
-    - name: Check /dev/nbd0 size
-      command: cat /sys/block/nbd0/size
-      register: nbd0_size
-      changed_when: False
-
-    - name: Attaching cnci image to /dev/ndb0
+    - name: Find available loop device
       become: yes
-      command: qemu-nbd -c /dev/nbd0 images/{{ cnci_image }} -f raw
-      when: nbd0_size.stdout == '0'
+      command: "losetup -f"
+      register: loop_device
 
-    - name: Run partprobe
+    - name: Mount cnci image on loop
       become: yes
-      command: partprobe /dev/nbd0
+      command: "losetup {{ loop_device.stdout }} -P images/{{ cnci_image }}"
 
     - name: Mounting cnci image in /mnt/tmp
       become: yes
       mount:
         name: /mnt/tmp
-        src: /dev/nbd0p2
+        src: "{{ loop_device.stdout }}p2"
         fstype: ext4
         state: mounted
 
@@ -102,12 +94,12 @@
       become: yes
       mount:
         name: /mnt/tmp
-        src: /dev/nbd0p2
+        src: {{ loop_device.stdout }}p2
         fstype: ext4
         state: absent
 
-    - name: Detach cnci image from /dev/ndb0
-      command: sudo qemu-nbd -d /dev/nbd0
+    - name: Detach cnci image from loop device
+      command: "losetup -d {{ loop_device.stdout }}"
 
     - name: Creating images/.cnci_ready
       file: path=images/.cnci_ready state=touch


### PR DESCRIPTION
the `qemu-nbd` tool it's used to manipulate the cnci image, which
is already a raw image (not qcow as thought), so we can use
raw image manipulation, removing all the need of nbd manipulation
tools.

Signed-off-by: Simental Magana, Marcos marcos.simental.magana@intel.com
