### PR TITLE
Docker: Start docker service in clearlinux

### DIFF
--- a/roles/docker/tasks/install_clearlinux.yml
+++ b/roles/docker/tasks/install_clearlinux.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  - name: Install containers-basic bundle
+  - name: Install containers-basic bundle (ClearLinux)
     command: swupd bundle-add containers-basic {{ swupd_args | default('') }}
     args:
       creates: /usr/share/clear/bundles/containers-basic

--- a/roles/docker/tasks/install_clearlinux.yml
+++ b/roles/docker/tasks/install_clearlinux.yml
@@ -17,3 +17,13 @@
     command: swupd bundle-add containers-basic {{ swupd_args | default('') }}
     args:
       creates: /usr/share/clear/bundles/containers-basic
+
+  - name: Check if host has /dev/kvm (ClearLinux)
+    stat: path=/dev/kvm
+    register: kvm
+
+  - name: Select docker runtime (ClearLinux)
+    set_fact: docker_service={{ 'docker-cor.service' if kvm.stat.exists else 'docker.service' }}
+
+  - name: Enable docker service (ClearLinux)
+    service: name={{ docker_service }} enabled=yes state=started

--- a/roles/docker/tasks/install_fedora.yml
+++ b/roles/docker/tasks/install_fedora.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  - name: Install docker repository
+  - name: Install docker repository (Fedora)
     yum_repository:
       name: docker
       description: Docker Repository
@@ -23,8 +23,8 @@
       gpgkey: https://yum.dockerproject.org/gpg
       gpgcheck: yes
 
-  - name: Install docker
+  - name: Install docker (Fedora)
     dnf: name=docker-engine state=present
 
-  - name: Start docker daemon
+  - name: Start docker daemon (Fedora)
     service: name=docker enabled=yes state=started

--- a/roles/docker/tasks/install_ubuntu.yml
+++ b/roles/docker/tasks/install_ubuntu.yml
@@ -13,30 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  - name: Install CA certificates
+  - name: Install CA certificates (Ubuntu)
     apt: name={{ item }} state=present
     with_items:
       - apt-transport-https
       - ca-certificates
       - linux-image-extra-{{ ansible_kernel }}
 
-  - name: Install docker repository GPG Key
+  - name: Install docker repository GPG Key (Ubuntu)
     apt_key:
       keyserver: hkp://p80.pool.sks-keyservers.net:80
       id: 72C52609D
       state: present
 
-  - name: Install docker repository
+  - name: Install docker repository (Ubuntu)
     apt_repository:
       repo: "deb https://apt.dockerproject.org/repo ubuntu-xenial experimental"
       state: present
       filename: docker
 
-  - name: Install docker
+  - name: Install docker (Ubuntu)
     apt: name={{ item }} state=present
     with_items:
       - docker-engine
       - python-docker
 
-  - name: Start docker daemon
+  - name: Start docker daemon (Ubuntu)
     service: name=docker enabled=yes state=started


### PR DESCRIPTION
After installing containers-basic bundle in clearlinux, docker services are not started.
