### PR TITLE
ciao-compute: Download OVMF.fd when RedHat-based distros

### DIFF
--- a/roles/ciao-compute/tasks/images.yml
+++ b/roles/ciao-compute/tasks/images.yml
@@ -18,7 +18,7 @@
 
   - name: Download OVMF.fd
     copy: src=images/OVMF.fd dest=/usr/share/qemu/OVMF.fd
-    when: ansible_os_family == "Debian"
+    when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"
 
   - name: Download Fedora Image
     copy: src=images/{{ fedora_cloud_image }} dest=/var/lib/ciao/images/{{ fedora_cloud_image }}


### PR DESCRIPTION
When using RedHat based compute nodes, it skips the copy of the file.
This commit adds a rule to handle the download when this scenario occurs.

Closes https://github.com/clearlinux/clear-config-management/issues/77
