### PR TITLE
ciao-controller: fix syntax typo while creating cnci image

### DIFF
--- a/roles/ciao-controller/tasks/create_cnci_image.yml
+++ b/roles/ciao-controller/tasks/create_cnci_image.yml
@@ -94,7 +94,7 @@
       become: yes
       mount:
         name: /mnt/tmp
-        src: {{ loop_device.stdout }}p2
+        src: "{{ loop_device.stdout }}p2"
         fstype: ext4
         state: absent
 


### PR DESCRIPTION
There is a yaml syntax error, so ansible will fail to run
`roles/ciao-controller/tasks/create_cnci_image.yml`

Signed-off-by: Simental Magana, Marcos marcos.simental.magana@intel.com
