### PR TITLE
ciao-compute/ciao-network: Ensure qemu processes stay alive

### DIFF
--- a/roles/ciao-compute/templates/ciao-compute.service.j2
+++ b/roles/ciao-compute/templates/ciao-compute.service.j2
@@ -8,6 +8,7 @@ ExecStart={{ bindir }}/ciao-launcher --cacert=/etc/pki/ciao/CAcert-{{ ciao_contr
                                  --cert=/etc/pki/ciao/cert-CNAgent-localhost.pem \
                                  --logtostderr -v 2
 Restart=always
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/ciao-network/templates/ciao-network.service.j2
+++ b/roles/ciao-network/templates/ciao-network.service.j2
@@ -8,6 +8,7 @@ ExecStart={{ bindir }}/ciao-launcher --cacert=/etc/pki/ciao/CAcert-{{ ciao_contr
                                  --cert=/etc/pki/ciao/cert-NetworkingAgent-localhost.pem \
                                  --logtostderr -v 2
 Restart=always
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When restarting ciao-launcher on the CN or NN it's important to keep the
qemu processes that they've started alive.

The default, KillMode=control-group, will result in all processes in
the control group being killed when the service is stopped. This will
include all the qemu processes created by ciao-launcher as they are
placed into the same cgroup by systemd.

Signed-off-by: Rob Bradford robert.bradford@intel.com
