### PR TITLE
ciao: Install ciao-cert on all nodes

### DIFF
--- a/roles/ciao-compute/tasks/install.yml
+++ b/roles/ciao-compute/tasks/install.yml
@@ -16,6 +16,7 @@
   - name: Copy CIAO Binaries
     copy: src={{ gopath }}/bin/{{ item }} dest={{ bindir }}/{{ item }} mode=755
     with_items:
+      - ciao-cert
       - ciao-cli
       - ciao-launcher
     when: ciao_dev

--- a/roles/ciao-controller/tasks/install.yml
+++ b/roles/ciao-controller/tasks/install.yml
@@ -16,9 +16,10 @@
   - name: Install CIAO binaries
     copy: src={{ gopath }}/bin/{{ item }} dest={{ bindir }}/{{ item }} mode=755
     with_items:
+      - ciao-cert
+      - ciao-cli
       - ciao-controller
       - ciao-scheduler
-      - ciao-cli
     when: ciao_dev
     notify:
       - restart scheduler

--- a/roles/ciao-network/tasks/install.yml
+++ b/roles/ciao-network/tasks/install.yml
@@ -16,6 +16,7 @@
   - name: Copy CIAO Binaries
     copy: src={{ gopath }}/bin/{{ item }} dest={{ bindir }}/{{ item }} mode=755
     with_items:
+      - ciao-cert
       - ciao-cli
       - ciao-launcher
     when: ciao_dev


### PR DESCRIPTION
ciao-cert now has a -dump parameter which gives information about
the certificates.

This change installs ciao-cert on all nodes with SSNTP certificates
as it is usefull to debug certificate issues.

Fixes #87

Signed-off-by: Alberto Murillo alberto.murillo.silva@intel.com
