### PR TITLE
ciao cleanup: Update the bundles to remove

### DIFF
--- a/examples/ciao/cleanup/ciao.yml
+++ b/examples/ciao/cleanup/ciao.yml
@@ -128,14 +128,12 @@
           command: swupd bundle-remove {{ item }} {{ swupd_args | default('') }}
           with_items:
             - cloud-control
-            - cloud-network
             - kvm-host
-            - libX11client
-            - net-utils
             - containers-basic
             - kernel-container
-            - network-advanced
+            - storage-cluster
             - storage-utils
+
           args:
             removes: /usr/share/clear/bundles/{{ item }}
       when: ansible_os_family == "Clear linux software for intel architecture"


### PR DESCRIPTION
Several bundles got deprecated in clearlinux.

This patch updates cleanup/ciao.yml to remove the bundles
that are actually installed by ciao.

Signed-off-by: Alberto Murillo alberto.murillo.silva@intel.com
