### PR TITLE
start docker containers after host reboot

### DIFF
--- a/roles/ciao-webui/handlers/main.yml
+++ b/roles/ciao-webui/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - name: reload systemd config
+    command: systemctl daemon-reload

--- a/roles/ciao-webui/tasks/main.yml
+++ b/roles/ciao-webui/tasks/main.yml
@@ -15,6 +15,13 @@
 
   - include: certificates.yml
 
+  - name: Create docker-ciao-webui systemd unit
+    template: src=docker-ciao-webui.service.j2 dest=/etc/systemd/system/docker-ciao-webui.service mode=0600
+    notify: reload systemd config
+
+  - name: Enable docker-ciao-webui systemd unit
+    service: name=docker-ciao-webui.service enabled=yes
+
   - name: Start ciao-webui container
     docker_container:
       name: ciao-webui

--- a/roles/ciao-webui/templates/docker-ciao-webui.service.j2
+++ b/roles/ciao-webui/templates/docker-ciao-webui.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=CIAO WebUI Container
+Requires={{ docker_service }}
+After={{ docker_service }}
+
+[Service]
+Restart=always
+ExecStart=/usr/bin/docker start -a ciao-webui
+ExecStop=/usr/bin/docker stop -t 2 ciao-webui
+
+[Install]
+WantedBy=default.target

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -13,14 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  - name: Install containers-basic bundle (ClearLinux)
-    command: swupd bundle-add containers-basic {{ swupd_args | default('') }}
-    args:
-      creates: /usr/share/clear/bundles/containers-basic
-
-  - name: Check if host has /dev/kvm (ClearLinux)
-    stat: path=/dev/kvm
-    register: kvm
-
-  - name: Select docker runtime (ClearLinux)
-    set_fact: docker_service={{ 'docker-cor.service' if kvm.stat.exists else 'docker.service' }}
+# Name of docker service
+docker_service: docker.service

--- a/roles/docker/tasks/install_fedora.yml
+++ b/roles/docker/tasks/install_fedora.yml
@@ -25,6 +25,3 @@
 
   - name: Install docker (Fedora)
     dnf: name=docker-engine state=present
-
-  - name: Start docker daemon (Fedora)
-    service: name=docker enabled=yes state=started

--- a/roles/docker/tasks/install_ubuntu.yml
+++ b/roles/docker/tasks/install_ubuntu.yml
@@ -37,6 +37,3 @@
     with_items:
       - docker-engine
       - python-docker
-
-  - name: Start docker daemon (Ubuntu)
-    service: name=docker enabled=yes state=started

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -21,3 +21,6 @@
 
 - include: install_clearlinux.yml
   when: ansible_os_family == "Clear linux software for intel architecture"
+
+- name: Start docker daemon
+  service: name={{ docker_service }} enabled=yes state=started

--- a/roles/keystone/handlers/main.yml
+++ b/roles/keystone/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - name: reload systemd config
+    command: systemctl daemon-reload

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -18,6 +18,13 @@
 
   - include: certificates.yml
 
+  - name: Create docker-keystone systemd unit
+    template: src=docker-keystone.service.j2 dest=/etc/systemd/system/docker-keystone.service mode=0600
+    notify: reload systemd config
+
+  - name: Enable docker-keystone systemd unit
+    service: name=docker-keystone.service enabled=yes
+
   - name: Start keystone container
     docker_container:
       name: ciao-keystone

--- a/roles/keystone/templates/docker-keystone.service.j2
+++ b/roles/keystone/templates/docker-keystone.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Keystone Container for CIAO
+Requires={{ docker_service }}
+After={{ docker_service }}
+
+[Service]
+Restart=always
+ExecStart=/usr/bin/docker start -a ciao-keystone
+ExecStop=/usr/bin/docker stop -t 2 ciao-keystone
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
keystone and ciao-webui containers are not started after the controller host is rebooted.
