### PR TITLE
ciao: Document fedora requirements

### DIFF
--- a/examples/ciao/README.md
+++ b/examples/ciao/README.md
@@ -12,11 +12,11 @@ on both the managed nodes and deployment machine.
 ### Requirements
 
 #### CIAO nodes
-* Ansible requirements for managed nodes can be found
-[here](http://docs.ansible.com/ansible/intro_installation.html#managed-node-requirements)
-
-* CIAO can be installed in ClearLinux, Fedora 24 and Ubuntu 16.04. Its dependencies
-will be installed automatically
+* Ansible requirements can be found
+[here](http://docs.ansible.com/ansible/intro_installation.html#managed-node-requirements),
+also check requirements for [fedora](https://github.com/clearlinux/clear-config-management/blob/master/examples/ciao/doc/requirements.md#fedora).
+* CIAO can be installed in ClearLinux, Fedora 24 and Ubuntu 16.04.
+CIAO dependencies will be installed automatically
 
 #### Deployment machine
 The deployment machine can be any Linux OS as long as it has the following requirements installed.

--- a/examples/ciao/doc/requirements.md
+++ b/examples/ciao/doc/requirements.md
@@ -1,0 +1,11 @@
+# Fedora
+## Ansible requirements
+Ansible requires the following packages to be present on fedora managed nodes:
+* python-dnf
+* netaddr
+* libselinux-python
+
+You can install them with the following command
+```
+sudo dnf install python-dnf netaddr libselinux-python
+```


### PR DESCRIPTION
When the managed nodes are fedora, they require the following
packages to be present:
- python-dnf
- netaddr
- libselinux-python

Fixes #50

Signed-off-by: Alberto Murillo alberto.murillo.silva@intel.com
