### PR TITLE
documentation: Add a note on disabling the firewall

### DIFF
--- a/examples/ciao/doc/requirements.md
+++ b/examples/ciao/doc/requirements.md
@@ -9,6 +9,14 @@ You can install them with the following command
 ```
 sudo dnf install python-dnf netaddr libselinux-python
 ```
+## Firewalld
+firewalld may cause cluster interoperability issues as rules need to be modified dinamically.
+We encourage the user to stop and disable the firewall.
+
+```
+sudo systemctl stop firewalld
+sudo systemctl disable firewalld
+```
 
 # Proxies
 A Proxy server needs to be configured in different parts of the system when deploying


### PR DESCRIPTION
When using fedora nodes with firewalld activated(default), it may cause
cluster interoperability issues due to dynamic interface spawn. So a note
on disabling the firewall is added.
