### PR TITLE
ciao-common: Copy ceph files

### DIFF
--- a/examples/ciao/README.md
+++ b/examples/ciao/README.md
@@ -65,6 +65,14 @@ compute3.example.com
 
 Optionally edit [group_vars/all](group_vars/all) file to change default passwords and other settings
 
+### Gather ceph config files
+Ciao storage is implemented to use ceph as its storage backend. For this reason all ciao nodes
+require a copy of the ceph configuration file and authentication token which can be found on
+/etc/ceph/ceph.conf and /etc/ceph/ceph.client.admin.keyring files in the ceph monitor node.
+
+In the working directoy, create a `ceph` folder and copy the ceph files mentioned above
+before proceeding to the next step.
+
 ---
 
 ### Run the playbook

--- a/roles/ciao-common/README.md
+++ b/roles/ciao-common/README.md
@@ -9,6 +9,7 @@ The following variables are available for all ciao roles
 
 Variable  | Default Value | Description
 --------  | ------------- | -----------
+cephx_user | admin | cephx user to login into the ceph cluster
 ciao_dev | False | Set to True to install from source, otherwise install form OS packages
 gopath | /tmp/go | golang GOPATH
 ciao_controller_fqdn | `{{ ansible_fqdn }}` | FQDN for CIAO controller node

--- a/roles/ciao-common/defaults/main.yml
+++ b/roles/ciao-common/defaults/main.yml
@@ -43,3 +43,6 @@ clear_cloud_image_url: https://download.clearlinux.org/releases/10820/clear/clea
 
 # Clearlinux cloud image file name
 clear_cloud_image: "{{ clear_cloud_image_url.split('/') | last | regex_replace('(.*).xz', '\\1') }}"
+
+# cephx user
+cephx_user: admin

--- a/roles/ciao-common/tasks/ceph.yml
+++ b/roles/ciao-common/tasks/ceph.yml
@@ -1,0 +1,23 @@
+---
+# Copyright (c) 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - name: Create /etc/ceph directory
+    file: path=/etc/ceph state=directory mode=600
+
+  - name: Copy ceph files
+    copy: src=ceph/{{ item }} dest=/etc/ceph/{{ item }} mode=400
+    with_items:
+      - ceph.conf
+      - "ceph.client.{{ cephx_user }}.keyring"

--- a/roles/ciao-common/tasks/main.yml
+++ b/roles/ciao-common/tasks/main.yml
@@ -50,3 +50,5 @@
       - include: install_fedora.yml
         when: ansible_os_family == "RedHat"
     when: not ciao_dev
+
+  - include: ceph.yml


### PR DESCRIPTION
Ciao relies on ceph as its storage back end.

This commit copies the ceph configuratino and authentication files to
each ciao node so they can make use of the ceph cluster.a

Fixes #95

Signed-off-by: Alberto Murillo Silva alberto.murillo.silva@intel.com
